### PR TITLE
Start adding params for using locally available isos

### DIFF
--- a/quickget
+++ b/quickget
@@ -1585,6 +1585,38 @@ fi
 LANGS=()
 languages_windows
 
+# handle parameters
+
+# Take command line arguments
+#if [ $# -lt 1 ]; then
+#    usage
+#    exit 0
+#else
+    while [ $# -gt 0 ]; do
+        case "${1}" in
+          -delete|--delete|-delete-disk|--delete-disk)
+            DELETE_DISK=1
+            shift;;
+          -isodir|--isodir)
+            ISODIR="${2}"
+            shift
+            shift;;
+          -localiso|--localiso)
+            LOCALISO="${2}"
+            shift
+            shift;;
+         -h|--h|-help|--help)
+            usage
+            exit 0;;
+          testing)
+             echo "you are just testing
+             ISODIR:  ${ISODIR}
+             LOCALISO: ${LOCALISO}"
+             exit 0;;
+          *)
+
+
+
 if [ -n "${1}" ]; then
     OS="${1,,}"
     if [ "${OS}" == "list" ] || [ "${OS}" == "list_csv" ]; then
@@ -1777,4 +1809,12 @@ else
         os_support
     fi
     exit 1
+fi
+;;
+   esac
+    done
+    if [ $# == 0 ]; then
+      echo "Error: You must supply an OS!"
+      os_support
+      exit 1
 fi

--- a/quickget
+++ b/quickget
@@ -436,9 +436,30 @@ function check_hash() {
     fi
 }
 
+function copy_local(){
+  if [ -n "${ISODIR}" ]; then
+    # use supplied filename or default to original distro ISO name
+      if [ -z ${LOCALISO} ]; then
+        LOCALISO=${FILE}
+      fi
+      LOCALFILE=$(find ${ISODIR} -type f -name "${LOCALISO}" -print -quit )
+      #echo got local file "${LOCALFILE}"
+      if [ -f "${DIR}/${FILE}" ]; then
+        echo "ERROR! File Exists - not copying over local file"
+        echo "Move it out of the way to replace it with a local file"
+        exit 1
+      else
+        cp -pv "${LOCALFILE}" ${DIR}/${FILE}
+      # if ! ; then echo ERROR! Failed to copy ${LOCALFILE}" to ${DIR}/${FILE}"
+      fi
+      #exit 0 # while testing
+    fi
+}
+
 function web_get() {
     local DIR="${2}"
     local FILE=""
+    local LOCALFILE=""
     local URL="${1}"
 
     if [ -n "${3}" ]; then
@@ -451,16 +472,19 @@ function web_get() {
       echo "ERROR! Unable to create directory ${DIR}"
       exit 1
     fi
+    copy_local
 
     if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
         echo "ERROR! Failed to download ${URL}. Try running 'quickget' again."
         exit 1
     fi
+
 }
 
 function zsync_get() {
     local DIR="${2}"
     local FILE=""
+    local LOCALFILE=""
     local OUT=""
     local URL="${1}"
     FILE="${URL##*/}"
@@ -479,6 +503,8 @@ function zsync_get() {
         echo "ERROR! Unable to create directory ${DIR}"
         exit 1
       fi
+
+    copy_local
 
       if ! zsync "${URL}.zsync" -i "${DIR}/${OUT}" -o "${DIR}/${OUT}" 2>/dev/null; then
           echo "ERROR! Failed to download ${URL}.zsync"
@@ -1595,6 +1621,8 @@ languages_windows
     while [ $# -gt 0 ]; do
         case "${1}" in
           -delete|--delete|-delete-disk|--delete-disk)
+          # This appears unused: function is present in quickemu
+          # if this was supposed to also work it needs finishing
             DELETE_DISK=1
             shift;;
           -isodir|--isodir)
@@ -1623,8 +1651,6 @@ languages_windows
              LOCALISO: ${LOCALISO}"
              exit 0;;
           *)
-
-
 
 if [ -n "${1}" ]; then
     OS="${1,,}"

--- a/quickget
+++ b/quickget
@@ -1608,7 +1608,16 @@ languages_windows
          -h|--h|-help|--help)
             usage
             exit 0;;
-          testing)
+         -l|--l|-list|--list|list|list_csv)
+            list_csv;;
+          -j|--j|-json|--json|list_json)
+            list_json;;
+          -v|--v|-version|--version|version )
+             whereIam=$(dirname "${BASH_SOURCE[0]}")
+              quickemu_version=$( "${whereIam}"/quickemu --version)
+              echo "Quickemu Version: ${quickemu_version}"
+              exit 0;;
+          test*)
              echo "you are just testing
              ISODIR:  ${ISODIR}
              LOCALISO: ${LOCALISO}"
@@ -1619,16 +1628,6 @@ languages_windows
 
 if [ -n "${1}" ]; then
     OS="${1,,}"
-    if [ "${OS}" == "list" ] || [ "${OS}" == "list_csv" ]; then
-        list_csv
-    elif [ "${OS}" == "list_json" ]; then
-        list_json
-    elif [ "${OS}" == "--version" ] || [ "${OS}" == "-version" ] || [ "${OS}" == "version" ]; then
-      whereIam=$(dirname "${BASH_SOURCE[0]}")
-      quickemu_version=$( "${whereIam}"/quickemu --version)
-      echo "Quickemu Version: ${quickemu_version}"
-      exit 0
-    fi
 else
     echo "ERROR! You must specify an operating system:"
     os_support


### PR DESCRIPTION
Attempting to add some options to use already-downloaded ISOs without having to manually pre-create vm directory and link/copy files in advance.

Rough plan is to support a directory and/or filename parameter or parameters.
If <directory> then add a `find <directory> ..` to find the expected ISO (or file specified in parameter) and later copy prior to wget or zsync (copy because we should be portable)

~Ideally if HASH is available then check before linking so if HASH fails then warn and continue to download~
leave hashing to catch user-induced corruption (e.g. `wget -c ` with a smaller older file )

As it stands, this will not copy a local file over an existing one, but a copied in file **will** form the base of the wget or zsync, so may be appended to if not identical in size or updated with zsync (at least that will not produce corruption)

Possibly add a kind of  `force` option to allow specifying a specific local file (which would require NOT checking remote hash and skipping wget/zsync entirely) 


